### PR TITLE
Update ac.lua

### DIFF
--- a/ac.lua
+++ b/ac.lua
@@ -1,15 +1,26 @@
+-- Anti-Cheat Remote Blocker
+-- Hook __namecall to intercept specific remote events
+
 local eventbypass
 
 eventbypass = hookmetamethod(game, "__namecall", function(self, ...)
     local method = getnamecallmethod()
-    local args = {...}
+    local args = { ... }
 
-    if not checkcaller() and self.Name == "AnalyticsReportEvent" and method == "FireServer" then
-        print("Anti Cheat remote was called and blocked.")
-        return; 
+    -- Check if the call is from the game environment and not from our script
+    if not checkcaller() then
+        local remoteName = self.Name
+        local className = self.ClassName
+
+        -- Targeting the "AnalyticsReportEvent" RemoteEvent specifically
+        if remoteName == "AnalyticsReportEvent" and method == "FireServer" then
+            warn("[Bypass] Blocked attempt to fire remote:", remoteName)
+            -- Optionally log more details about the attempted call
+            -- print("Arguments:", unpack(args))
+            return
+        end
     end
 
+    -- Call the original __namecall method
     return eventbypass(self, ...)
 end)
-
-


### PR DESCRIPTION
This PR adds an extended version of the __namecall hook to block the AnalyticsReportEvent remote. The code is now more readable, includes comments for clarity, and logs blocked attempts using warn(). No behavioral changes have been made — just improved structure and maintainability for future edits or expansions.